### PR TITLE
Update license field to proper spdx short identifier.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "executionenvironment"
   ],
   "author": "Jed Watson",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/JedWatson/exenv/issues"
   },


### PR DESCRIPTION
Noticed this randomly. BSD has one or two strange variants, figured helpful to specify this is not one of them. 

