### PR TITLE
Fix SPDX license expression.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "executionenvironment"
   ],
   "author": "Jed Watson",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/JedWatson/exenv/issues"
   },


### PR DESCRIPTION
In `package.json`, only `BSD` was given (without any notice, whether it should be 2-clause, 3-clause, or 4-clause BSD). According to the `LICENSE` file, it is 3-clause.

So, I've updated `package.json` accordingly with the correct SPDX license expression.

(You need this for automatically checking license compatibility, so it would be great if you could merge this 😊)