### PR TITLE
Remove UMD an make exenv a pure CommonJS module.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,38 +3,26 @@
   Based on code that is Copyright 2013-2015, Facebook, Inc.
   All rights reserved.
 */
-/* global define */
 
-(function () {
-	'use strict';
+'use strict';
 
-	var canUseDOM = !!(
-		typeof window !== 'undefined' &&
-		window.document &&
-		window.document.createElement
-	);
+var canUseDOM = !!(
+	typeof window !== 'undefined' &&
+	window.document &&
+	window.document.createElement
+);
 
-	var ExecutionEnvironment = {
+var ExecutionEnvironment = {
 
-		canUseDOM: canUseDOM,
+	canUseDOM: canUseDOM,
 
-		canUseWorkers: typeof Worker !== 'undefined',
+	canUseWorkers: typeof Worker !== 'undefined',
 
-		canUseEventListeners:
-			canUseDOM && !!(window.addEventListener || window.attachEvent),
+	canUseEventListeners:
+		canUseDOM && !!(window.addEventListener || window.attachEvent),
 
-		canUseViewport: canUseDOM && !!window.screen
+	canUseViewport: canUseDOM && !!window.screen
 
-	};
+};
 
-	if (typeof define === 'function' && typeof define.amd === 'object' && define.amd) {
-		define(function () {
-			return ExecutionEnvironment;
-		});
-	} else if (typeof module !== 'undefined' && module.exports) {
-		module.exports = ExecutionEnvironment;
-	} else {
-		window.ExecutionEnvironment = ExecutionEnvironment;
-	}
-
-}());
+module.exports = ExecutionEnvironment;


### PR DESCRIPTION
Reduces bundle sizes and helps tools like rollup inline the code.

This is based on the assumption that `exenv` is, in practice, always used as a CommonJS module. This should be be a server major release.