### PR TITLE
give canUseDOM with a possibility to be a constant

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@
 
 	var canUseDOM = !!(
 		typeof window !== 'undefined' &&
-		window.document &&
-		window.document.createElement
+		typeof window.document !== 'undefined' &&
+		typeof window.document.createElement !== 'undefined'
 	);
 
 	var ExecutionEnvironment = {


### PR DESCRIPTION
https://webpack.js.org/plugins/define-plugin/

Webpack's DefinePlugin has the ability to replace typeof expr to a constant in compile-time, which should lead to better dead-code-elimination.

(I've sent the same change to react https://github.com/facebook/react/pull/14194 )
